### PR TITLE
Ensure case insensitive email address comparison

### DIFF
--- a/mutt-ical.py
+++ b/mutt-ical.py
@@ -203,10 +203,10 @@ if __name__ == "__main__":
     flag = 1
     for attendee in attendees:
         if hasattr(attendee, 'EMAIL_param'):
-            if attendee.EMAIL_param == email_address:
+            if attendee.EMAIL_param.lower() == email_address.lower():
                 ans.vevent.attendee_list.append(attendee)
                 flag = 0
-        elif attendee.value.split(':')[1] == email_address:
+        elif attendee.value.split(':')[1].lower() == email_address.lower():
             ans.vevent.attendee_list.append(attendee)
             flag = 0
     if flag:


### PR DESCRIPTION
This patch makes sure that comparison of email addresses is case insensitive. Before this patch, the script would return "Seems like you have not been invited to this event!" if the email address in the invitation (defined by the event organizer) had different capitalization than the provided email address in the mandatory -e option of the script (defined by the user).

The patch makes sure that email addresses will match, irrespective of the chosen capitalization.